### PR TITLE
fix: bypass deep link attempts in Safari to prevent error messages

### DIFF
--- a/src/features/widgets/utils/deep-link.ts
+++ b/src/features/widgets/utils/deep-link.ts
@@ -165,10 +165,12 @@ export const openDeepLink = async (
   // Always log the attempt for debugging
   logDeepLinkDebug(config, "Attempting to use deep link");
   
-  // Use a shorter timeout for environments where we know deep links won't work well
+  // Skip deep link attempt for Safari or other environments where deep links show errors
+  // Go directly to App Store or web fallback instead
   if (!canUseNativeDeepLinks()) {
-    logDeepLinkDebug(config, "Environment has limited deep link support, using shorter timeout");
-    timeout = 500; // Use a shorter timeout for Safari/etc
+    logDeepLinkDebug(config, "Environment has limited deep link support, going directly to store/fallback URL");
+    window.open(config.webFallbackUrl, '_blank');
+    return;
   }
   
   return new Promise((resolve) => {


### PR DESCRIPTION
When attempting to open deep links in Safari or PWAs on iOS, error messages were being shown before redirecting to the App Store. This change now detects problematic environments and skips directly to the store URL instead of attempting the deep link first, providing a better user experience while maintaining the original functionality in supported browsers.